### PR TITLE
feat: add support for tags, fetch memes sorted by popularity

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,26 +6,31 @@
 
 <div class="container">
   <form class="entry-form" [formGroup]="form" (ngSubmit)="onSubmit()">
-    <mat-form-field class="entry-form__input">
-      <mat-label>Meme URL</mat-label>
-      <input formControlName="url" matInput type="url" />
-      <mat-error>Por favor ingresa una URL válida</mat-error>
-    </mat-form-field>
-    <button
-      mat-raised-button
-      color="primary"
-      [disabled]="addingMeme"
-      type="submit"
-    >
-      <mat-spinner
-        class="entry-form__spinner"
-        [diameter]="22"
-        *ngIf="addingMeme; else notAdding"
-      ></mat-spinner>
-      <ng-template #notAdding> Send </ng-template>
-    </button>
+    <div class="entry-form__wrapper">
+      <div class="entry-form__main">
+        <mat-form-field class="entry-form__input">
+          <mat-label>Meme URL</mat-label>
+          <input formControlName="url" matInput type="url" />
+          <mat-error>Please add a valid URL</mat-error>
+        </mat-form-field>
+        <button
+          mat-raised-button
+          color="primary"
+          [disabled]="addingMeme"
+          type="submit"
+        >
+          <mat-spinner
+            class="entry-form__spinner"
+            [diameter]="22"
+            *ngIf="addingMeme; else notAdding"
+          ></mat-spinner>
+          <ng-template #notAdding> Send </ng-template>
+        </button>
+      </div>
+      <app-tags class="entry-form__tags" [allowedTags]="TAGS" formControlName="tags"></app-tags>
+    </div>
   </form>
-  <div *ngIf="user$ | async as user">
+  <div *ngIf="user$ | async as user" class="admin-toggle">
     <mat-slide-toggle
       *ngIf="user.role.admin"
       color="primary"
@@ -43,6 +48,7 @@
         [isUpvoted]="getLikesMap()[meme.id]"
         [isAdmin]="adminView | async"
         (like)="likeMeme(meme)"
+        (delete)="deleteMeme(meme)"
         (approveChange)="changeApproval($event)"
       ></app-meme>
     </mat-card>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -18,6 +18,7 @@
 .entry-form {
   display: flex;
   align-items: center;
+  flex-direction: column;
 
   &__input {
     flex-grow: 1;
@@ -27,6 +28,23 @@
   &__spinner {
     margin: 10px auto;
   }
+
+  &__main {
+    display: flex;
+    align-items: center;
+  }
+
+  &__wrapper {
+    width: 100%;
+  }
+
+  &__tags {
+    display: block;
+  }
+}
+
+.admin-toggle {
+  margin-top: 20px;
 }
 
 .mat-toolbar-row {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,9 +11,10 @@ import { MemeComponent } from './components/meme/meme.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { LoginComponent } from './components/login/login.component';
 import { NgMaterialModule } from './shared/ng-material/ng-material.module';
+import { TagsComponent } from './components/tags/tags.component';
 
 @NgModule({
-  declarations: [AppComponent, MemeComponent, LoginComponent],
+  declarations: [AppComponent, MemeComponent, LoginComponent, TagsComponent],
   imports: [
     BrowserModule,
     AngularFireModule.initializeApp(environment.firebase),

--- a/src/app/components/meme/meme.component.html
+++ b/src/app/components/meme/meme.component.html
@@ -2,14 +2,16 @@
 
 <div class="meme__footer">
   <p class="meme__likes">{{ meme.likes }} upvotes</p>
-  <mat-slide-toggle
-    *ngIf="isAdmin"
-    color="primary"
-    [checked]="meme.approved"
-    (toggleChange)="changeApproval()"
-  >
-    {{ meme.approved ? 'Meme aprobado' : 'Meme no aprobado' }}
-  </mat-slide-toggle>
+  <ng-container *ngIf="isAdmin">
+    <mat-slide-toggle
+      color="primary"
+      [checked]="meme.approved"
+      (toggleChange)="changeApproval()"
+    >
+      {{ meme.approved ? 'Approved' : 'Not approved' }}
+    </mat-slide-toggle>
+    <button mat-raised-button color="secondary" (click)="delete.emit()">Delete 🗑</button>
+  </ng-container>
   <button
     mat-raised-button
     [disabled]="isUpvoted"

--- a/src/app/components/meme/meme.component.ts
+++ b/src/app/components/meme/meme.component.ts
@@ -20,6 +20,9 @@ export class MemeComponent {
   like = new EventEmitter<void>();
 
   @Output()
+  delete = new EventEmitter<void>();
+
+  @Output()
   approveChange = new EventEmitter();
 
   changeApproval() {

--- a/src/app/components/tags/tags.component.html
+++ b/src/app/components/tags/tags.component.html
@@ -1,0 +1,6 @@
+<mat-chip-list aria-label="Tag selection">
+  <mat-chip color="accent" 
+            *ngFor="let tag of allowedTags"
+            (click)="toggleTag(tag)"
+            [class.selected]="isTagSelected(tag)">{{ tag }}</mat-chip>
+</mat-chip-list>

--- a/src/app/components/tags/tags.component.scss
+++ b/src/app/components/tags/tags.component.scss
@@ -1,0 +1,4 @@
+.selected {
+  background: #ff4081;
+  color: white;
+}

--- a/src/app/components/tags/tags.component.ts
+++ b/src/app/components/tags/tags.component.ts
@@ -1,0 +1,49 @@
+import { Component, forwardRef, Input } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+
+@Component({
+  selector: 'app-tags',
+  templateUrl: './tags.component.html',
+  styleUrls: ['./tags.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TagsComponent),
+      multi: true
+    }
+  ]
+})
+export class TagsComponent implements ControlValueAccessor {
+
+  @Input()
+  allowedTags: string[] = [];
+
+  selectedTags: string[] = [];
+
+  propagateChange = (_: any) => { };
+
+  writeValue(tags: string[]): void {
+    this.selectedTags = tags || [];
+  }
+
+  registerOnChange(fn: () => {}): void {
+    this.propagateChange = fn;
+  }
+
+  toggleTag(tag: string) {
+    const idx = this.selectedTags.indexOf(tag);
+    if (idx === -1) {
+      this.selectedTags.push(tag);
+    } else {
+      this.selectedTags.splice(idx, 1);
+    }
+    this.propagateChange(this.selectedTags);
+  }
+
+  isTagSelected(tag: string) {
+    return this.selectedTags.indexOf(tag) !== -1;
+  }
+
+  registerOnTouched(): void { }
+
+}

--- a/src/app/models/meme.interface.ts
+++ b/src/app/models/meme.interface.ts
@@ -3,4 +3,5 @@ export interface Meme {
   approved: boolean;
   id?: string;
   likes: number;
+  tags: string[];
 }

--- a/src/app/shared/ng-material/ng-material.module.ts
+++ b/src/app/shared/ng-material/ng-material.module.ts
@@ -8,6 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatChipsModule } from '@angular/material/chips';
 
 const matModules = [
   MatInputModule,
@@ -18,6 +19,7 @@ const matModules = [
   MatProgressSpinnerModule,
   MatSnackBarModule,
   MatSlideToggleModule,
+  MatChipsModule,
 ];
 
 @NgModule({
@@ -25,4 +27,4 @@ const matModules = [
   imports: [CommonModule, matModules],
   exports: [matModules],
 })
-export class NgMaterialModule {}
+export class NgMaterialModule { }


### PR DESCRIPTION
This PR contains the following:
- Fetches the list sorted by likes (desc). I created a Firestore index for this.
- Allow users to add tags when submitting memes
- Allow admins to delete memes

![2020-05-15 18 12 04](https://user-images.githubusercontent.com/3689856/82103338-3ab0f780-96d8-11ea-83d5-4c517307ee2b.gif)


Closes #6